### PR TITLE
Add cryptographic functions to SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Verify that the `v1` signature is valid using a library of your choice (we use [
 If the signature is valid, compute the difference between the current timestamp and the received epoch,
 and decide if the difference is within your tolerance. We use a tolerance of 5 minutes.
 
-#### Additional checks
+#### Additional Checks
 
 - Check that request is for an expected form by verifying the form ID
 - Check that the submission ID is new, and that your system has not received it before

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const app = require('express')()
 const formsg = require('@opengovsg/formsg')()
 
 // This is where your domain is hosted, and should match
-// the URI supplied to FormSGin the form dashboard
+// the URI supplied to FormSG in the form dashboard
 const POST_URI = 'https://my-domain.com/submissions'
 
 // Your form's secret key downloaded from FormSG upon form creation

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-const webhooks = require('./src/webhooks.js')
+const webhooks = require('./src/webhooks')
+const crypto = require('./src/crypto')
 
 /**
  * Entrypoint into the FormSG SDK
@@ -12,6 +13,7 @@ module.exports = function ({
   webhookSecretKey,
 } = {}) {
     return {
-      webhooks: webhooks({ mode, webhookSecretKey })
+      webhooks: webhooks({ mode, webhookSecretKey }),
+      crypto: crypto(),
     }
 }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,6 @@ module.exports = function ({
 } = {}) {
     return {
       webhooks: webhooks({ mode, webhookSecretKey }),
-      crypto: crypto(),
+      crypto,
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,12 @@
       "integrity": "sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA==",
       "dev": true
     },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "tweetnacl-util": "^0.15.1"
   },
   "devDependencies": {
-    "jasmine": "^3.5.0"
+    "jasmine": "^3.5.0",
+    "lodash": "^4.17.15"
   }
 }

--- a/spec/crypto.spec.js
+++ b/spec/crypto.spec.js
@@ -1,0 +1,53 @@
+const _ = require('lodash')
+
+const formsg = require('../index')()
+
+const {
+  plaintext,
+  ciphertext,
+  formSecretKey,
+  formPublicKey,
+} = require('./resources/crypto-data-20200322')
+
+describe('Crypto', function () {
+
+  it('should generate a keypair', () => {
+    const keypair = formsg.crypto.generate()
+    expect(Object.keys(keypair)).toContain('secretKey')
+    expect(Object.keys(keypair)).toContain('publicKey')
+  })
+
+  it('should generate a keypair that is valid', () => {
+    const { publicKey, secretKey } = formsg.crypto.generate()
+    expect(formsg.crypto.valid(publicKey, secretKey)).toBe(true)
+  })
+
+  it('should validate an existing keypair', () => {
+    expect(formsg.crypto.valid(formPublicKey, formSecretKey)).toBe(true)
+  })
+
+  it('should invalidate unassociated keypairs', () => {
+    const { secretKey } = formsg.crypto.generate()
+    const { publicKey } = formsg.crypto.generate()
+    expect(formsg.crypto.valid(
+      publicKey,
+      secretKey,
+    )).toBe(false)
+  })
+
+  it('should decrypt the submission ciphertext from 2020-03-22 successfully', () => {
+    const decryptedPlaintext = formsg.crypto.decrypt(formSecretKey, ciphertext)
+    expect(_.isEqual(decryptedPlaintext, plaintext)).toBe(true)
+  })
+
+  it('should return null on unsuccessful decryption', () => {
+    expect(formsg.crypto.decrypt('random', ciphertext)).toBe(null)
+  })
+
+  it('should be able to encrypt and decrypt submissions from 2020-03-22 end-to-end successfully', () => {
+    const { publicKey, secretKey } = formsg.crypto.generate()
+    const ciphertext = formsg.crypto.encrypt(publicKey, plaintext)
+    const decrypted = formsg.crypto.decrypt(secretKey, ciphertext)
+    expect(_.isEqual(decrypted, plaintext)).toBe(true)
+  })
+})

--- a/spec/resources/crypto-data-20200322.js
+++ b/spec/resources/crypto-data-20200322.js
@@ -1,0 +1,97 @@
+/**
+ * DO NOT MODIFY THE DATA BELOW.
+ * 
+ * The below data represents a submission from 2020-03-22.
+ * It must remain unmodified to maintain strict backwards compatibility.
+ * 
+ * If changes are necessary, create new test data instead.
+ */
+
+const plaintext = [{
+  "_id": "5e7479c786eaf2002488a211",
+  "question": "Header",
+  "fieldType": "section",
+  "isHeader": true,
+  "answer": ""
+}, {
+  "_id": "5e7479a086eaf2002488a20e",
+  "question": "Email",
+  "fieldType": "email",
+  "answer": "test@open.gov.sg"
+}, {
+  "_id": "5e771c246b3c5100240368d8",
+  "question": "Mobile Number",
+  "fieldType": "mobile",
+  "answer": "+6598765432"
+}, {
+  "_id": "5e7479a386eaf2002488a20f",
+  "question": "Number",
+  "fieldType": "number",
+  "answer": "123"
+}, {
+  "_id": "5e771c346b3c5100240368da",
+  "question": "Decimal",
+  "fieldType": "decimal",
+  "answer": "0.123"
+}, {
+  "_id": "5e771c516b3c5100240368dc",
+  "question": "Short Text",
+  "fieldType": "textfield",
+  "answer": "Test"
+}, {
+  "_id": "5e771c596b3c5100240368dd",
+  "question": "Long Text",
+  "fieldType": "textarea",
+  "answer": "Long\nText"
+}, {
+  "_id": "5e771c626b3c5100240368de",
+  "question": "Dropdown",
+  "fieldType": "dropdown",
+  "answer": "Option 1"
+}, {
+  "_id": "5e771c666b3c5100240368df",
+  "question": "Yes/No",
+  "fieldType": "yes_no",
+  "answer": "Yes"
+}, {
+  "_id": "5e771c7a6b3c5100240368e0",
+  "question": "Checkbox",
+  "fieldType": "checkbox",
+  "answerArray": ["Option 2"]
+}, {
+  "_id": "5e771c8a6b3c5100240368e1",
+  "question": "Radio",
+  "fieldType": "radiobutton",
+  "answer": "Option 1"
+}, {
+  "_id": "5e771c8d6b3c5100240368e2",
+  "question": "Date",
+  "fieldType": "date",
+  "answer": "22 Mar 2020"
+}, {
+  "_id": "5e771c906b3c5100240368e3",
+  "question": "Rating",
+  "fieldType": "rating",
+  "answer": "5"
+}, {
+  "_id": "5e771c946b3c5100240368e4",
+  "question": "NRIC",
+  "fieldType": "nric",
+  "answer": "S9912345A"
+}]
+
+const ciphertext = 'RqOjwNXwiVJqvdTrQeD/NiktpI8vzo6CXlBBNihmmwI=;+0cGJwOA42F7DmQO7Kr6tNn9YH/7poDe:2jpehB9uW+63G1EimxOs1tsfR54xxSVZQbFMQaCa8ovVoF/6isBCEl5WLmrE1CRa2c5L2G5rAgCUnhsxQ7jVa//XEKr/m9kGNMbPnVqH62RslAxh30Mzz2he/ssbMazLDBzgQwd8I+pHnrBHQW5BsLqclj7QAMX3fa10Zon0ih4irWQ1o9eYitFllitD+vIcwbBzJyigGvD/t14+2/5imZmJdmJTJXd1ySxDo1X6KjBmph4rzvWtZSUgF7rRfMtAmbyOj87i6CkkNNIN4Dtl3zEuSeLuU2IDF7IHDdAwpmgWM9ejFpwrMFfr8PRovCubuRxCDQ1hV6GOyh60SlKA3oHQMhRQ2yia2vr9yxzHgO+wVUfgoiXQn8tvXFwZmzZd/eWENC1QI+XvP1jt50RIhQ0kMbyhBiaAG9nYlhGO3UHtmGGBoOdW4l4DZaWKRItnw1qgb2oxCvxOIkWNoafq1qJbYJsldOy6a/I2lbwAPL7MzVfgHJDj11dLOBgHGZHia6ZaROXYEiFpkVP8APOO/tgV902nOOlt+w63QNIieCIoGphn9LvOTo6Y6HD8qH6sekEyXCds6jP4RVw5XIN9LGeOWlEKx/VR2rf8b9qzFcYRPzfH5M8I9rpuZkk72ANiTeLRM8C8zWFnitzDlh1B2M+jnjrg+jEYm0ugro7tvHYSmU4tKcGR3mPlDrROjtFf3eBO8+pZKzuQfdA/7kN5YekAzyNjLcixioycrDmjR+BbBKxVrwNlm0hmHLLdU1g42GYpmfUUythDnqwALAOtaZcuj1ObX50h6kmhIl4fAEcXdLKKpoASzafbHnIH0iNX1CefnflLxymDPjjTFqcGSpY1vZf2pxDxUNZPXsd3vbV4KbrYq9v/R5NJ+mW3lxm839aN0pNsMbMetyZTyX8tXofWERxKEZDDXRCoYS0Ijml5h0X58juM13hNtc48iuPyx8oBIy4WophJ+M4CJfsq1wfBK0q+a8P2Tj8odJRQbbFdCoQRRRKbFhk0nT/R3V23cRjMB/Z1DCFmo8ywhUfSlMhrs8f6f3myhmJpzP5MXPJgzRIAytYtUF34j+9fspaYtyQHg4j4f8OBIYrNOCgt6++1bmy0+aI3Y0DoBJ1eLfe9iHUt64cvPbPqmAxX8Jkb1kY+OVwjx7DTxFc5dCzkL/3VA1FAZe7IqfP0v/3fTT6oK7nuy951GUSU9sBynV8Z6zJecYUWbgFZ1u/K8ag6btR2IeRFz7dG+Ffkb8nsGTcNm0l54Q/XbudtfIPN2GTGp1PlgFZ5JERszVrQ8MIrMnHtPvnbtIlqdVzZ0KwR1YQnqtjCoNnI/TzniRZnydE/qJCc5ZwAQDJhl0XRmVes5sp4obxhreSdgGjoyybeFN70rb6uMvsuBlTS5Z6xg7q4eW0e8Xx0PlKYJi8eUsFtzQlN3iJzgFTeLGOlguK2GWnI/Myy5/nan2Np5+eZ2GZhdn6s/NYmiJGLlcbmcXRLOj53O1Z9Oornc+Hq5rz+eZKg4uYNbyFCbvJ9d/wNbRaQva9kETeEfGVosZXotnA2dxYRF4A24Qwjo+yNeRlbyQBf0V0BWY+rfJ+F2JMP4LZ5FNVhd5JI16z7PEgqvlGqm7zkfPmwlTjCzDFXYz749fz9hrzqOCALguEhmMYEsun8mK7IptW77qbKyx2jTu/2OC6pqdWhHB3PliKZXD5EgedpqzHcWQg/s9TloSXy9pE9PEs0j+el+j4yXyQcfrAjODWHSrUXNWSJc1rOM1ochIYJWYHn4pf2Jxuop90+c4DFYp5eih3k8BGy4Etp6L0N7PJ+ugSqZV8L0QYT2sLBwG2cS8FNUGJPoUkUn6R2Bg7bTQ=='
+
+const formSecretKey = 'H7B0nKJ+E7+naSkQApxGayz1y/lZe4thta4iPp1B+Ns='
+const formPublicKey = 'NKHcx/SuUfBxhXe20yoVTCsDwQTSfrd5MMClCOrd/js='
+const submissionSecretKey = '9h1ys0ZpcPD9pBShwtE4YKXv8882ldjd9sF51YS3Fks='
+const submissionPublicKey = 'RqOjwNXwiVJqvdTrQeD/NiktpI8vzo6CXlBBNihmmwI='
+
+module.exports = {
+  plaintext,
+  ciphertext,
+  formSecretKey,
+  formPublicKey,
+  submissionSecretKey,
+  submissionPublicKey,
+}

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -86,7 +86,7 @@ function decrypt (formPrivateKey, encryptedSubmission) {
  * A cryptographic keypair
  * @typedef {Keypair}
  * @property {string} publicKey The base-64 encoded public key
- * @property {string} privateKey The base-64 encoded privateKey key
+ * @property {string} secretKey The base-64 encoded secret key
  */
 
 /**

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -55,7 +55,7 @@ function encrypt (formPublicKey, responses) {
     decodeUTF8(JSON.stringify(responses)),
     nonce,
     decodeBase64(formPublicKey),
-    decodeBase64(submissionPrivateKey)
+    decodeBase64(submissionKeypair.secretKey)
   ))
   return `${submissionKeypair.publicKey};${encodeBase64(nonce)}:${encrypted}`
 }
@@ -107,11 +107,10 @@ function generate () {
  * @param {string} secretKey 
  */
 function valid (publicKey, secretKey) {
-  const text = 'testtext'
+  const plaintext = 'testtext'
   try {
-    const encrypted = encryptSubmission(publicKey, text)
-    const decrypted = decryptSubmission(secretKey, encrypted)
-    return decrypted === text
+    const ciphertext = encrypt(publicKey, plaintext)
+    return decrypt(secretKey, ciphertext) === plaintext
   } catch (err) {
     return false
   }

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -1,7 +1,64 @@
 'use strict'
 
-const tweetnacl = require('tweetnacl')
-const { decodeBase64, encodeUTF8 } = require('tweetnacl-util')
+const nacl = require('tweetnacl')
+const {
+  encodeBase64,
+  decodeBase64,
+  encodeUTF8,
+  decodeUTF8
+} = require('tweetnacl-util')
+
+/**
+ * A field type available in FormSG as a string
+ * @typedef {FieldType}
+ * @type {string}
+ * @example
+ * 'section'
+ * 'radiobutton'
+ * 'dropdown'
+ * 'checkbox'
+ * 'nric'
+ * 'email'
+ * 'table'
+ * 'number'
+ * 'rating'
+ * 'yes_no'
+ * 'decimal'
+ * 'textfield' // Short Text
+ * 'textarea' // Long Text
+ * 'attachment'
+ * 'date'
+ * 'mobile'
+ */
+
+/**
+ * The complete Triforce, or one or more components of the Triforce.
+ * @typedef {Response}
+ * @property {string} _id - The field ID of the response
+ * @property {string} question - The form question
+ * @property {string} answer - The answer to the form
+ * @property {FieldType} fieldType - The field type
+ */
+
+/**
+ * Encrypts submission with a unique keypair for each submission
+ * @param {String} formPublicKey base64
+ * @param {Response[]} responses Array of Response objects
+ * @returns encrypted basestring containing the submission public key,
+ * nonce and encrypted data in base64
+ * @throws error if any of the encrypt methods fail
+ */
+function encrypt (formPublicKey, responses) {
+  const submissionKeypair = generate()
+  const nonce = nacl.randomBytes(24)
+  const encrypted = encodeBase64(nacl.box(
+    decodeUTF8(JSON.stringify(responses)),
+    nonce,
+    decodeBase64(formPublicKey),
+    decodeBase64(submissionPrivateKey)
+  ))
+  return `${submissionKeypair.publicKey};${encodeBase64(nonce)}:${encrypted}`
+}
 
 /**
  * Decrypts an encrypted submission.
@@ -13,7 +70,7 @@ function decrypt (formPrivateKey, encryptedSubmission) {
   try {
     const [ submissionPublicKey, nonceEncrypted ] = encryptedSubmission.split(';')
     const [ nonce, encrypted ] = nonceEncrypted.split(':').map(decodeBase64)
-    const decrypted = tweetnacl.box.open(
+    const decrypted = nacl.box.open(
       encrypted,
       nonce,
       decodeBase64(submissionPublicKey),
@@ -25,8 +82,46 @@ function decrypt (formPrivateKey, encryptedSubmission) {
   }
 }
 
+/**
+ * A cryptographic keypair
+ * @typedef {Keypair}
+ * @property {string} publicKey The base-64 encoded public key
+ * @property {string} privateKey The base-64 encoded privateKey key
+ */
+
+/**
+ * Generates a new keypair for encryption.
+ * @returns {Keypair}
+ */
+function generate () {
+  const kp = nacl.box.keyPair()
+  return {
+    publicKey: encodeBase64(kp.publicKey),
+    secretKey: encodeBase64(kp.secretKey),
+  }
+}
+
+/**
+ * Checks whether a public & private keypair are associated with each other
+ * @param {string} publicKey 
+ * @param {string} secretKey 
+ */
+function valid (publicKey, secretKey) {
+  const text = 'testtext'
+  try {
+    const encrypted = encryptSubmission(publicKey, text)
+    const decrypted = decryptSubmission(secretKey, encrypted)
+    return decrypted === text
+  } catch (err) {
+    return false
+  }
+}
+
 module.exports = function () {
   return {
+    encrypt,
     decrypt,
+    generate,
+    valid,
   }
 }

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -10,8 +10,7 @@ const {
 
 /**
  * A field type available in FormSG as a string
- * @typedef {FieldType}
- * @type {string}
+ * @typedef {string} FieldType
  * @example
  * 'section'
  * 'radiobutton'
@@ -32,8 +31,8 @@ const {
  */
 
 /**
- * The complete Triforce, or one or more components of the Triforce.
- * @typedef {Response}
+ * Represents an answer provided to a form question.
+ * @typedef {object} Response
  * @property {string} _id - The field ID of the response
  * @property {string} question - The form question
  * @property {string} answer - The answer to the form
@@ -41,11 +40,17 @@ const {
  */
 
 /**
+ * Encrypted basestring containing the submission public key,
+ * nonce and encrypted data in base-64.
+ * @typedef {string} EncryptedContent
+ * A string in the format of <SubmissionPublicKey>;<Base64Nonce>:<Base64EncryptedData> 
+ */
+
+/**
  * Encrypts submission with a unique keypair for each submission
  * @param {String} formPublicKey base64
  * @param {Response[]} responses Array of Response objects
- * @returns encrypted basestring containing the submission public key,
- * nonce and encrypted data in base64
+ * @returns {EncryptedContent}
  * @throws error if any of the encrypt methods fail
  */
 function encrypt (formPublicKey, responses) {
@@ -63,12 +68,12 @@ function encrypt (formPublicKey, responses) {
 /**
  * Decrypts an encrypted submission.
  * @param {string} formPrivateKey base64
- * @param {string} encryptedSubmission encrypted string encoded in base64
+ * @param {EncryptedContent} encryptedContent encrypted string encoded in base64
  * @return {Object | null} Parsed JSON submission object if successful.
  */
-function decrypt (formPrivateKey, encryptedSubmission) {
+function decrypt (formPrivateKey, encryptedContent) {
   try {
-    const [ submissionPublicKey, nonceEncrypted ] = encryptedSubmission.split(';')
+    const [ submissionPublicKey, nonceEncrypted ] = encryptedContent.split(';')
     const [ nonce, encrypted ] = nonceEncrypted.split(':').map(decodeBase64)
     const decrypted = nacl.box.open(
       encrypted,
@@ -83,8 +88,8 @@ function decrypt (formPrivateKey, encryptedSubmission) {
 }
 
 /**
- * A cryptographic keypair
- * @typedef {Keypair}
+ * A base-64 encoded cryptographic keypair suitable for curve25519.
+ * @typedef {Object} Keypair
  * @property {string} publicKey The base-64 encoded public key
  * @property {string} secretKey The base-64 encoded secret key
  */
@@ -102,7 +107,7 @@ function generate () {
 }
 
 /**
- * Checks whether a public & private keypair are associated with each other
+ * Returns true if a pair of public & secret keys are associated with each other
  * @param {string} publicKey 
  * @param {string} secretKey 
  */
@@ -116,11 +121,9 @@ function valid (publicKey, secretKey) {
   }
 }
 
-module.exports = function () {
-  return {
-    encrypt,
-    decrypt,
-    generate,
-    valid,
-  }
+module.exports = {
+  encrypt,
+  decrypt,
+  generate,
+  valid,
 }

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const tweetnacl = require('tweetnacl')
+const { decodeBase64, encodeUTF8 } = require('tweetnacl-util')
+
+/**
+ * Decrypts an encrypted submission.
+ * @param {string} formPrivateKey base64
+ * @param {string} encryptedSubmission encrypted string encoded in base64
+ * @return {Object | null} Parsed JSON submission object if successful.
+ */
+function decrypt (formPrivateKey, encryptedSubmission) {
+  try {
+    const [ submissionPublicKey, nonceEncrypted ] = encryptedSubmission.split(';')
+    const [ nonce, encrypted ] = nonceEncrypted.split(':').map(decodeBase64)
+    const decrypted = tweetnacl.box.open(
+      encrypted,
+      nonce,
+      decodeBase64(submissionPublicKey),
+      decodeBase64(formPrivateKey)
+    )
+    return JSON.parse(encodeUTF8(decrypted))
+  } catch (err) {
+    return null
+  }
+}
+
+module.exports = function () {
+  return {
+    decrypt,
+  }
+}


### PR DESCRIPTION
## Problem

The SDK currently contains utilities for web hook signature verification, but is incomplete without the functionality necessary to decrypt form responses.

## Solution 

This PR adds the following functionality under the `crypto` module:

- Decryption
- Encryption
- Keypair generation
- Keypair validation

as well as corresponding tests for the above.

##  Post-merge

Bump minor version number and publish to NPM.


_Reviewers, please take note that this is a public repository._
