### PR TITLE
Compatibility patch for Internet Explorer

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,6 @@ module.exports = function ({
 } = {}) {
     return {
       webhooks: webhooks({ mode, webhookSecretKey }),
-      crypto,
+      crypto
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/formsg-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Node.js SDK for integrating with FormSG",
   "main": "index.js",
   "scripts": {

--- a/spec/crypto.spec.js
+++ b/spec/crypto.spec.js
@@ -29,10 +29,7 @@ describe('Crypto', function () {
   it('should invalidate unassociated keypairs', () => {
     const { secretKey } = formsg.crypto.generate()
     const { publicKey } = formsg.crypto.generate()
-    expect(formsg.crypto.valid(
-      publicKey,
-      secretKey,
-    )).toBe(false)
+    expect(formsg.crypto.valid(publicKey, secretKey)).toBe(false)
   })
 
   it('should decrypt the submission ciphertext from 2020-03-22 successfully', () => {

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -102,7 +102,7 @@ function generate () {
   const kp = nacl.box.keyPair()
   return {
     publicKey: encodeBase64(kp.publicKey),
-    secretKey: encodeBase64(kp.secretKey),
+    secretKey: encodeBase64(kp.secretKey)
   }
 }
 
@@ -125,5 +125,5 @@ module.exports = {
   encrypt,
   decrypt,
   generate,
-  valid,
+  valid
 }

--- a/src/util/parser.js
+++ b/src/util/parser.js
@@ -22,5 +22,5 @@ function parseSignatureHeader (header) {
 }
 
 module.exports = {
-  parseSignatureHeader,
+  parseSignatureHeader
 }

--- a/src/util/signature.js
+++ b/src/util/signature.js
@@ -39,5 +39,5 @@ function verify (message, signature, publicKey) {
 
 module.exports = {
   sign,
-  verify,
+  verify
 }

--- a/src/webhooks.js
+++ b/src/webhooks.js
@@ -113,6 +113,6 @@ module.exports = function ({ mode, webhookSecretKey }) {
     authenticate: authenticate(webhookPublicKey),
     /* Signing functions */
     generateSignature: webhookSecretKey ? generateSignature(webhookSecretKey) : undefined,
-    constructHeader: webhookSecretKey ? constructHeader : undefined,
+    constructHeader: webhookSecretKey ? constructHeader : undefined
   }
 }


### PR DESCRIPTION
Problem
- IE cannot deal with trailing commas

Solution
- Remove trailing commas wherever found in the codebase
