### PR TITLE
Destructure options in the function body

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,12 +8,17 @@ const crypto = require('./src/crypto')
  * the SDK for the FormSG staging environment
  * @param {string} [options.webhookSecretKey] Optional base64 secret key for signing webhooks
  */
-module.exports = function ({
-  mode='production',
-  webhookSecretKey,
-} = {}) {
-    return {
-      webhooks: webhooks({ mode, webhookSecretKey }),
-      crypto,
-    }
+module.exports = function (options) {
+  const {
+    mode = 'production',
+    webhookSecretKey,
+  } = options || {}
+
+  return {
+    webhooks: webhooks({
+      mode,
+      webhookSecretKey
+    }),
+    crypto,
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/formsg-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/formsg-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Node.js SDK for integrating with FormSG",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Problem

Destructuring in the function parameter with default arguments is ignored in Babel, which causes issues in IE11.

# Solution

Destructure parameters ourselves in function body.